### PR TITLE
FIx pip install . cause file copy loss

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,6 @@ setup(
     packages=find_packages(include=["ReplenishmentEnv"]),
     include_package_data=True,
     package_data={
-        "ReplenishmentEnv": ["config/*.yml", "data/*/*", "ReplenishmentEnv.*py"],
+        "ReplenishmentEnv": ["config/*.yml", "data/*/*", "env/*/*", "utility/*", "wrapper/*", "ReplenishmentEnv.*py"],
     }
 )


### PR DESCRIPTION
issue: install this by `pip install .` would not copy all python files.

solution: copy all dirs/files